### PR TITLE
Fix building the extension on Windows (and Node 25)

### DIFF
--- a/scripts/builder/AssetBase.ts
+++ b/scripts/builder/AssetBase.ts
@@ -65,7 +65,8 @@ export class AssetBase {
   }
 
   formatRelativePath(p: string) {
-    return `${path.relative(path.dirname(this.outputPath.value || ''), p)}`
+    // Web-extension manifests require POSIX separators; normalize for Windows.
+    return path.relative(path.dirname(this.outputPath.value || ''), p).split(path.sep).join('/')
   }
 
   onStop(fn: AssetBase['onStopHandlers'][0]) {

--- a/scripts/builder/AssetManifest.ts
+++ b/scripts/builder/AssetManifest.ts
@@ -3,7 +3,7 @@ import type { FSWatcher } from 'chokidar'
 import chokidar from 'chokidar'
 import { getProperty as deepGet, deepKeys, setProperty as deepSet } from 'dot-prop'
 import path from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { pathToFileURL } from 'node:url'
 import { parse } from 'semver'
 
 import type { AssetType } from './AssetBase.ts'
@@ -101,7 +101,7 @@ export class AssetManifest extends AssetParent {
   override async init() {
     this.outputPath.value = path.join(this.opts.dist, 'manifest.json')
 
-    const modulePath = `${fileURLToPath(new URL(this.inputPath, import.meta.url))}?t=${Date.now()}`
+    const modulePath = `${pathToFileURL(this.inputPath).href}?t=${Date.now()}`
     const module = await import(modulePath) as { default: () => Record<string, unknown> }
     const manifest = module.default()
 

--- a/scripts/builder/esbuild.ts
+++ b/scripts/builder/esbuild.ts
@@ -69,8 +69,8 @@ function AssetPlugin(asset: AssetMain) {
           for (const [outputPath, meta] of Object.entries(metafile?.outputs ?? {})) {
             if (meta.entryPoint) {
               delete metafile?.outputs[outputPath]
-              outputFiles = outputFiles?.filter(f => f.path !== join(asset.opts.root, outputPath))
-              outputFiles = outputFiles?.filter(f => f.path !== join(asset.opts.root, `${outputPath}.map`))
+              outputFiles = outputFiles?.filter(f => f.path !== resolve(asset.opts.root, outputPath))
+              outputFiles = outputFiles?.filter(f => f.path !== resolve(asset.opts.root, `${outputPath}.map`))
             }
           }
         }
@@ -121,7 +121,7 @@ function AssetPlugin(asset: AssetMain) {
             (meta.entryPoint && join(asset.opts.root, meta.entryPoint) === asset.inputPath)
             || (asset.type === 'other' && relative(asset.opts.src, asset.inputPath) === relative(asset.opts.dist, outputPath))
           ) {
-            asset.outputPath.value = join(asset.opts.root, outputPath)
+            asset.outputPath.value = resolve(asset.opts.root, outputPath)
           }
         }
 

--- a/scripts/builder/vite.ts
+++ b/scripts/builder/vite.ts
@@ -3,7 +3,7 @@ import unocss from '@unocss/vite'
 import vue from '@vitejs/plugin-vue'
 import type { Ref } from '@vue/reactivity'
 import { Buffer } from 'node:buffer'
-import { dirname, join, relative } from 'node:path'
+import { dirname, join, relative, resolve } from 'node:path'
 import RekaResolver from 'reka-ui/resolver'
 import { visualizer } from 'rollup-plugin-visualizer'
 import type { ImportCommon } from 'unimport'
@@ -11,7 +11,6 @@ import { builtinPresets } from 'unimport'
 import autoImport from 'unplugin-auto-import/vite'
 import vueComponents from 'unplugin-vue-components/vite'
 import type * as vite from 'vite'
-import vueDevTools from 'vite-plugin-vue-devtools'
 
 import { ICONS_CUSTOM_COLLECTIONS, ICONS_TRANSFORM } from '#uno.config'
 
@@ -23,9 +22,44 @@ import { logBuild, makeHash, writeFile } from './utils.ts'
 
 const ORIGIN_PLACEHOLDER = '__VITE_ORIGIN__'
 
+/**
+ * Guarantee a usable `localStorage` global before vue-devtools loads. Node 25
+ * defines `localStorage` by default but leaves its methods unavailable unless
+ * `--localstorage-file` is set, which makes @vue/devtools-kit throw at import.
+ * A tiny in-memory shim is all the build/serve process needs.
+ */
+function ensureLocalStorage(): void {
+  const current = (globalThis as { localStorage?: { getItem?: unknown } }).localStorage
+  if (current && typeof current.getItem === 'function')
+    return
+
+  const store = new Map<string, string>()
+  const shim = {
+    get length() { return store.size },
+    clear() { store.clear() },
+    getItem: (key: string) => (store.has(key) ? store.get(key)! : null),
+    key: (index: number) => Array.from(store.keys())[index] ?? null,
+    removeItem: (key: string) => { store.delete(key) },
+    setItem: (key: string, value: string) => { store.set(key, String(value)) },
+  }
+  Object.defineProperty(globalThis, 'localStorage', { configurable: true, value: shim })
+}
+
 export async function createViteConfig(asset: AssetPage, inputs: ViteInput[], origin?: Ref<string | null>) {
   const { opts: { root, src, command } } = asset
   const dist = dirname(join(asset.opts.dist, relative(src, asset.inputPath)))
+
+  // Imported lazily: vite-plugin-vue-devtools pulls in @vue/devtools-kit, which
+  // reads `localStorage` at import time. Node 25 defines a `localStorage` global
+  // (and `navigator`, so the lib assumes a browser) but leaves its methods
+  // unavailable without `--localstorage-file`, so the import otherwise throws
+  // "localStorage.getItem is not a function". Shim it, and only load in dev.
+  let devtoolsPlugins: vite.PluginOption[] = []
+  if (process.env.NODE_ENV === 'development') {
+    ensureLocalStorage()
+    const { default: VueDevtools } = await import('vite-plugin-vue-devtools')
+    devtoolsPlugins = [VueDevtools({ appendTo: inputs[0]!.inputPath })]
+  }
 
   return {
     configFile: false,
@@ -128,11 +162,7 @@ export async function createViteConfig(asset: AssetPage, inputs: ViteInput[], or
       visualizer({
         filename: join(asset.opts.dist, relative(src, asset.inputPath).replace(/\.html?$/, '.stats.html')),
       }),
-      ...(process.env.NODE_ENV === 'development'
-        ? [vueDevTools({
-          appendTo: inputs[0]!.inputPath,
-        })]
-        : []),
+      ...devtoolsPlugins,
     ],
   } as vite.InlineConfig
 
@@ -173,7 +203,9 @@ export async function createViteConfig(asset: AssetPage, inputs: ViteInput[], or
         // Update asset paths
         for (const [fileName, chunk] of Object.entries(bundle)) {
           for (const input of inputs) {
-            if (chunk.type === 'chunk' && chunk.facadeModuleId === input.inputPath) {
+            // Rollup normalizes facadeModuleId to forward slashes; input.inputPath
+            // uses OS separators. Compare via resolve() so they match on Windows.
+            if (chunk.type === 'chunk' && chunk.facadeModuleId && resolve(chunk.facadeModuleId) === resolve(input.inputPath)) {
               input.setAttrs(join(dist, fileName), true)
               if (chunk.viteMetadata?.importedCss)
                 input.cssBundlePaths = [...chunk.viteMetadata.importedCss].map(p => join(dist, p))

--- a/uno.config.ts
+++ b/uno.config.ts
@@ -1,6 +1,7 @@
 import { objectKeys, objectPick } from '@antfu/utils'
 import { parseCssColor, variantGetParameter } from '@unocss/rule-utils'
-import { resolve } from 'node:path'
+import { createRequire } from 'node:module'
+import { fileURLToPath } from 'node:url'
 import * as svgo from 'svgo'
 import type { Preset, PresetWind3Theme, UserConfig, UserShortcuts, VariantObject } from 'unocss'
 import { presetAttributify, presetIcons, presetWind3, transformerDirectives } from 'unocss'
@@ -55,8 +56,17 @@ export const COLORS = {
   },
 } as const
 
+// Load installed @iconify-json/* collections explicitly. autoInstall/FS auto-discovery
+// is unreliable here (pnpm's nested store + Windows), so we provide them directly.
+const iconifyRequire = createRequire(import.meta.url)
+const iconifyCollection = (name: string) => () => iconifyRequire(`@iconify-json/${name}/icons.json`)
+
 export const ICONS_CUSTOM_COLLECTIONS = {
-  ao3e: FileSystemIconLoader(resolve(new URL('./src/icons', import.meta.url).pathname)),
+  ao3e: FileSystemIconLoader(fileURLToPath(new URL('./src/icons', import.meta.url))),
+  'codicon': iconifyCollection('codicon'),
+  'mdi': iconifyCollection('mdi'),
+  'tabler': iconifyCollection('tabler'),
+  'line-md': iconifyCollection('line-md'),
 }
 
 export const ICONS_TRANSFORM = (svg: string) => svgo.optimize(svg, SVGO_CONFIG).data


### PR DESCRIPTION
## Problem

Building the extension on Windows currently fails. On a clean checkout,
`node scripts/builder/build.ts build` throws before producing usable output:

```
TypeError [ERR_INVALID_URL_SCHEME]: The URL must be of scheme file
```

and once that's worked around, the generated `manifest.json` contains broken
absolute paths like `../../C:/.../background.js`.

This PR makes the build run cleanly on Windows (and on Node 25). The changes
are small, self-contained, and written to be no-ops / equivalent on
Linux & macOS.

## Changes

**POSIX separators + file URLs** — `AssetBase.ts`, `AssetManifest.ts`
- Normalize manifest paths with `.split(path.sep).join('/')`; `path.relative()`
  returns backslashes on Windows, which are invalid in web-extension manifests.
- Build the manifest module specifier with `pathToFileURL().href`. Dynamic
  `import()` of a raw Windows path fails because ESM requires a `file://` URL —
  this is the `ERR_INVALID_URL_SCHEME` above.

**Vite config** — `vite.ts`
- Compare `chunk.facadeModuleId` to input paths via `path.resolve()` (Rollup
  normalizes `facadeModuleId` to forward slashes while input paths use OS
  separators), so asset paths are actually rewritten on Windows.
- Import `vite-plugin-vue-devtools` lazily (dev only) behind a tiny in-memory
  `localStorage` shim. On Node 25 the static import pulls in `@vue/devtools-kit`,
  which reads `localStorage` at import time and throws.

**esbuild output paths** — `esbuild.ts`
- Use `path.resolve()` instead of `path.join()` for `asset.outputPath`, so it's
  absolute and the later relative-path computation yields correct manifest
  entries instead of `../../C:/...`.

**Icon collections** — `uno.config.ts`
- Use `fileURLToPath()` instead of `URL.pathname` (which yields `/D:/...` on
  Windows) for the custom icon dir, and load the installed `@iconify-json/*`
  collections explicitly via `createRequire`, since FS auto-discovery is
  unreliable with pnpm's nested store on Windows.

## Verification

Tested on Windows 11 with Node 25 / pnpm 11:

- **Before:** build crashes with `ERR_INVALID_URL_SCHEME`.
- **After:** `pnpm build` (Firefox + Chrome, production) completes, and both
  `manifest.json` files contain only clean relative paths
  (`background/background.js`, `icons/icon.svg`, …) — no backslashes or
  drive-letter paths.

Each commit is independent, if you'd prefer to take them separately.
